### PR TITLE
feat(web): UI refresh — compact navbar, bottom drawer chatbot, and status-aware todo cards

### DIFF
--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -250,3 +250,99 @@ p {
     border: none;
     margin: 5px;
   }
+
+/* ── Navbar ─────────────────────────────────────── */
+.site-navbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 20px;
+    background: var(--card);
+    border-bottom: 1px solid #e5e7eb;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.navbar-logo img {
+    display: block;
+}
+
+.navbar-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #f1f5f9;
+    border-radius: 20px;
+    padding: 6px 14px;
+    flex: 1;
+    max-width: 320px;
+}
+
+.navbar-search input {
+    border: none;
+    background: transparent;
+    outline: none;
+    font-size: 14px;
+    width: 100%;
+    color: var(--text-primary);
+}
+
+.navbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+}
+
+.btn-primary-nav {
+    background: var(--teal);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.btn-outline-nav {
+    background: transparent;
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+/* ── Stats bar ──────────────────────────────────── */
+.stats-bar {
+    display: flex;
+    gap: 10px;
+    padding: 10px 20px;
+    background: var(--surface);
+}
+
+.stat-pill {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 80px;
+}
+
+.stat-count {
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.stat-label {
+    font-size: 9px;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}

--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -1,3 +1,22 @@
+/* ── Color tokens ───────────────────────────────── */
+:root {
+  --teal:           #0d9488;
+  --teal-light:     #f0fdfa;
+  --teal-border:    #99f6e4;
+  --green:          #22c55e;
+  --amber:          #f59e0b;
+  --surface:        #f0f2f5;
+  --card:           #ffffff;
+  --text-primary:   #111827;
+  --text-secondary: #64748b;
+  --border:         #e2e8f0;
+}
+
+body {
+  background: var(--surface);
+  margin: 0;
+}
+
 #logo {
     width: 55%;
 }
@@ -227,12 +246,6 @@ p {
 
   .chat-input input[type="text"] {
     flex: 1;
-    padding: 10px;
-    border: none;
-    margin: 5px;
-  }
-
-  button {
     padding: 10px;
     border: none;
     margin: 5px;

--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -346,3 +346,83 @@ p {
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
+
+/* ── Todo cards ─────────────────────────────────── */
+.todo-card {
+    background: var(--card);
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-left-style: solid;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.todo-card.status-inprogress { border-left-color: var(--teal); }
+.todo-card.status-done       { border-left-color: var(--green); }
+.todo-card.status-overdue    { border-left-color: var(--amber); }
+
+.todo-card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.todo-title {
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--text-primary);
+}
+
+.todo-title-done {
+    text-decoration: line-through;
+    color: var(--text-secondary);
+}
+
+.todo-badge {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    white-space: nowrap;
+    font-weight: 500;
+    flex-shrink: 0;
+}
+
+.badge-inprogress { background: #f0fdf4; color: #16a34a; }
+.badge-done       { background: #f0fdf4; color: var(--green); }
+.badge-overdue    { background: #fffbeb; color: #d97706; }
+
+.todo-desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.todo-due {
+    font-size: 12px;
+    color: var(--text-secondary);
+    display: block;
+    margin: 0;
+}
+
+.todo-open-btn {
+    width: 100%;
+    background: var(--teal-light);
+    color: var(--teal);
+    border: 1px solid var(--teal-border);
+    border-radius: 6px;
+    padding: 6px 0;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.todo-open-btn-muted {
+    opacity: 0.5;
+}

--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -169,87 +169,201 @@ p {
     }
 }
 
-.chat-tab {
+/* ── Chat FAB ───────────────────────────────────── */
+.chat-fab {
     position: fixed;
-    bottom: 10px;
-    right: 10px;
-    width: 60px; /* Adjust if necessary to match your design */
-    height: 60px; /* Adjust if necessary to match your design */
-    border-radius: 50%; /* This gives the circular shape */
-    overflow: hidden; /* Ensures no overflow outside the circular shape */
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2); /* Optional: Adds a shadow for better visibility */
+    bottom: 24px;
+    right: 24px;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #0d9488, #0891b2);
+    color: #fff;
+    font-size: 18px;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(13, 148, 136, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+    padding: 0;
+}
+
+/* ── Chat Drawer ────────────────────────────────── */
+.chat-drawer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 45vh;
+    background: var(--card);
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.12);
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    transform: translateY(100%);
+    transition: transform 300ms ease-out;
+}
+
+.chat-drawer.open {
+    transform: translateY(0);
+}
+
+.drawer-handle {
+    width: 36px;
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    margin: 10px auto 0;
+    flex-shrink: 0;
+}
+
+.drawer-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.drawer-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--teal);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    flex-shrink: 0;
+}
+
+.drawer-identity {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.drawer-identity strong {
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.drawer-status {
+    font-size: 11px;
+    color: var(--green);
+}
+
+.drawer-close {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    padding: 4px;
+    line-height: 1;
+}
+
+/* ── Chat Messages ──────────────────────────────── */
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    background: #fafafa;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.message {
+    max-width: 80%;
+    padding: 8px 12px;
+    font-size: 14px;
+    line-height: 1.4;
+    border-radius: 8px;
+}
+
+.message.bot {
+    align-self: flex-start;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 4px 14px 14px 14px;
+    color: var(--text-primary);
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.bot-avatar-sm {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--teal);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.message.user {
+    align-self: flex-end;
+    background: var(--teal);
+    color: #fff;
+    border-radius: 14px 4px 14px 14px;
+}
+
+.message.typing {
+    align-self: flex-start;
+    color: var(--text-secondary);
+    font-style: italic;
+    background: none;
+    border: none;
+    padding: 4px 8px;
+}
+
+/* ── Chat Input ─────────────────────────────────── */
+.chat-input-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.chat-pill-input {
+    flex: 1;
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    padding: 8px 16px;
+    background: #f8fafc;
+    font-size: 14px;
+    outline: none;
+    color: var(--text-primary);
+}
+
+.chat-send-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--teal);
+    color: #fff;
+    border: none;
+    font-size: 14px;
     cursor: pointer;
     display: flex;
-    justify-content: center;
     align-items: center;
-  }
-  
-  #chatIcon {
-    width: 100%; /* Makes the image fill the container */
-    height: auto; /* Maintains the aspect ratio of the image */
-  }
-
-  .chat-container {
-    position: fixed;
-    bottom: 70px; /* Position above the chat-tab */
-    right: 10px;
-    width: 300px;
-    height: 400px;
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    background-color: #f9f9f9;
-    display: none; /* Initially hide the chat */
-    flex-direction: column;
-  }
-
-  .messages {
-    flex: 1;
-    padding: 10px;
-    overflow-y: auto;
-  }
-
-  .message {
-    margin-bottom: 10px;
-    padding: 10px;
-    border-radius: 5px;
-    background-color: #f1f1f1;
-  }
-  
-  .message img {
-    vertical-align: middle;
-    margin-right: 5px;
-  }
-
-  .message.user {
-    background-color: #007bff; /* Light gray background for user messages */
-    color: white; /* White text for readability */
-    border-radius: 10px;
-    padding: 5px 10px;
-    margin: 5px;
-    max-width: 80%;
-    align-self: flex-end; /* Align user messages to the right */
-  }
-
-  .message.bot {
-    background-color:#f1f1f1 ; /* Blue background for bot messages */
-    color: black; /* Black text for readability */
-    border-radius: 10px;
-    padding: 5px 10px;
-    margin: 5px;
-    max-width: 80%;
-    align-self: flex-start; /* Align bot messages to the left */
-  }
-
-  .chat-input {
-    display: flex;
-  }
-
-  .chat-input input[type="text"] {
-    flex: 1;
-    padding: 10px;
-    border: none;
-    margin: 5px;
-  }
+    justify-content: center;
+    padding: 0;
+    flex-shrink: 0;
+}
 
 /* ── Navbar ─────────────────────────────────────── */
 .site-navbar {

--- a/apps/web/home.html
+++ b/apps/web/home.html
@@ -43,6 +43,27 @@
         </div>
     </div>
 
+    <!-- Chat FAB -->
+    <button id="chatFab" class="chat-fab" aria-label="Open assistant">✦</button>
+
+    <!-- Chat Drawer -->
+    <div id="chatDrawer" class="chat-drawer">
+        <div class="drawer-handle"></div>
+        <div class="drawer-header">
+            <div class="drawer-avatar">✦</div>
+            <div class="drawer-identity">
+                <strong>Assistant</strong>
+                <span class="drawer-status">● Online</span>
+            </div>
+            <button id="chatCloseBtn" class="drawer-close" aria-label="Close">✕</button>
+        </div>
+        <div class="chat-messages" id="chatMessages"></div>
+        <div class="chat-input-row">
+            <input type="text" id="userInput" placeholder="Type a message…" class="chat-pill-input">
+            <button id="sendMessageButton" class="chat-send-btn">➤</button>
+        </div>
+    </div>
+
     <!-- Todos list -->
     <div class="container">
         <div id="todosList" class="row"></div>

--- a/apps/web/home.html
+++ b/apps/web/home.html
@@ -12,43 +12,36 @@
 </head>
 <body id="body">
 
-    <!-- Logo -->
-    <div class="container-fluid" style="text-align: center">
-        <a class="navbar-brand" href="#">
-            <img src="img/logo.png" id="logo" align="center"/>
+    <!-- Navbar -->
+    <nav class="site-navbar">
+        <a href="#" class="navbar-logo">
+            <img src="img/logo.png" alt="Logo" style="height:36px;width:auto;">
         </a>
-    </div>
-    <br><br>
+        <div class="navbar-search">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+            <input type="text" id="searchTodosFilter" placeholder="Search todos…">
+        </div>
+        <div class="navbar-actions">
+            <button type="button" id="addTodoButton" class="btn-primary-nav" data-toggle="modal" data-target="#newTodoModal">+ New todo</button>
+            <button type="button" id="signOutButton" class="btn-outline-nav">Sign out</button>
+        </div>
+    </nav>
 
-    <!-- Chatbot -->
-    <div class="chat-tab">
-        <img src="img/bot-icon.gif" alt="Chat with us!" style="width: 100%; height: 100%;">
-    </div>
-    <div class="chat-container">
-        <div class="messages" id="chatMessages"></div>
-        <div class="chat-input">
-            <input type="text" id="userInput" placeholder="Type a message...">
-            <button id="sendMessageButton">Send</button>
+    <!-- Stats bar -->
+    <div class="stats-bar">
+        <div class="stat-pill">
+            <span class="stat-count" id="statTotal" style="color:var(--teal)">0</span>
+            <span class="stat-label">TOTAL</span>
+        </div>
+        <div class="stat-pill">
+            <span class="stat-count" id="statInProgress" style="color:var(--amber)">0</span>
+            <span class="stat-label">IN PROGRESS</span>
+        </div>
+        <div class="stat-pill">
+            <span class="stat-count" id="statDone" style="color:var(--green)">0</span>
+            <span class="stat-label">DONE</span>
         </div>
     </div>
-
-    <!-- Toolbar -->
-    <div class="container">
-        <div class="btn-toolbar float-left">
-            <input type="text" id="searchTodosFilter" placeholder="Search todo.." name="searchTodo">
-            <button type="button" id="searchTodosButton" class="btn btn-outline-light btn-sm">
-                <img src="img/search.png" title="search" id="search-img"/>
-            </button>
-            &nbsp;
-            <button type="button" id="showAllTodosButton" class="btn btn-primary btn-sm">Show All</button>
-        </div>
-        <div class="btn-toolbar float-right">
-            <button type="button" id="addTodoButton" class="btn btn-success btn-nav" data-toggle="modal" data-target="#newTodoModal">New todo</button>
-            &nbsp;
-            <button type="button" id="signOutButton" class="btn btn-dark btn-nav">Sign out</button>
-        </div>
-    </div>
-    <br><br>
 
     <!-- Todos list -->
     <div class="container">

--- a/apps/web/src/chatbot.ts
+++ b/apps/web/src/chatbot.ts
@@ -62,9 +62,11 @@ export function displayMessage(text: string, sender: Sender = 'user'): void {
     const messageElement = document.createElement('div');
     messageElement.classList.add('message', sender);
 
-    const botIcon = '<img src="public/img/bot-icon.svg" alt="Bot" style="width: 20px; height: 20px;"> ';
-    const icon = sender === 'user' ? '&#128100; ' : botIcon;
-    messageElement.innerHTML = icon + text;
+    if (sender === 'bot') {
+        messageElement.innerHTML = '<span class="bot-avatar-sm">✦</span>' + text;
+    } else {
+        messageElement.textContent = text;
+    }
 
     chatMessages.appendChild(messageElement);
     chatMessages.scrollTop = chatMessages.scrollHeight;

--- a/apps/web/src/pages/home.ts
+++ b/apps/web/src/pages/home.ts
@@ -12,21 +12,28 @@ document.addEventListener('DOMContentLoaded', () => {
     // Sign out button
     document.getElementById('signOutButton')?.addEventListener('click', logOut);
 
-    // Chatbot toggle
-    const chatTab = document.querySelector('.chat-tab');
-    const chatContainer = document.querySelector('.chat-container') as HTMLElement | null;
-    chatTab?.addEventListener('click', () => {
-        if (!chatContainer) return;
-        const isOpen = chatContainer.style.display === 'flex';
-        if (isOpen) {
-            chatContainer.style.display = 'none';
-            closeChatSession();
-        } else {
-            chatContainer.style.display = 'flex';
-            openChatSession();
-            (document.getElementById('userInput') as HTMLInputElement)?.focus();
-        }
-    });
+    // Chatbot — FAB and drawer toggle
+    const chatFab = document.getElementById('chatFab') as HTMLElement | null;
+    const chatDrawer = document.getElementById('chatDrawer') as HTMLElement | null;
+    const chatCloseBtn = document.getElementById('chatCloseBtn') as HTMLElement | null;
+
+    function openDrawer(): void {
+        if (!chatDrawer || !chatFab) return;
+        chatDrawer.classList.add('open');
+        chatFab.style.display = 'none';
+        openChatSession();
+        (document.getElementById('userInput') as HTMLInputElement)?.focus();
+    }
+
+    function closeDrawer(): void {
+        if (!chatDrawer || !chatFab) return;
+        chatDrawer.classList.remove('open');
+        chatFab.style.display = 'flex';
+        closeChatSession();
+    }
+
+    chatFab?.addEventListener('click', openDrawer);
+    chatCloseBtn?.addEventListener('click', closeDrawer);
 
     // Chatbot send on Enter
     document.getElementById('userInput')?.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/apps/web/src/ui.ts
+++ b/apps/web/src/ui.ts
@@ -50,24 +50,52 @@ import { Todo, TodoFile } from './types';
   export function renderTodos(todos: Todo[]): void {
       const list = getElement('todosList');
       if (!list) return;
-      list.innerHTML = todos.map(todo => `
-          <div class="col-md-4 border border-info" style="margin-bottom: 1rem;">
-              <br>
-              <p align="center">
-                  <strong>${todo.title}</strong><br>
-                  ${todo.description}<br>
-                  <b>Due Date:</b> ${todo.dateDue}<br>
-                  <button type="button"
-                      class="btn btn-sm"
-                      data-toggle="modal"
-                      data-target="#descriptionModal"
-                      data-todoid="${todo.todoID}">
-                      Details
-                  </button>
-              </p>
-              <br>
-          </div>
-      `).join('');
+
+      const today = new Date().toISOString().split('T')[0];
+
+      list.innerHTML = todos.map(todo => {
+          const isOverdue = !todo.completed && !!todo.dateDue && todo.dateDue < today;
+          const statusClass = todo.completed ? 'status-done' : isOverdue ? 'status-overdue' : 'status-inprogress';
+          const badgeHtml = todo.completed
+              ? '<span class="todo-badge badge-done">✓ Done</span>'
+              : isOverdue
+                  ? '<span class="todo-badge badge-overdue">⚠ Overdue</span>'
+                  : '<span class="todo-badge badge-inprogress">● In progress</span>';
+          const titleClass = todo.completed ? 'todo-title-done' : '';
+
+          return `
+<div class="col-md-4 mb-3">
+  <div class="todo-card ${statusClass}">
+    <div class="todo-card-top">
+      <span class="todo-title ${titleClass}">${todo.title}</span>
+      ${badgeHtml}
+    </div>
+    <p class="todo-desc">${todo.description}</p>
+    <p class="todo-due">📅 ${todo.dateDue || '—'}</p>
+    <button type="button"
+        class="todo-open-btn${todo.completed ? ' todo-open-btn-muted' : ''}"
+        data-toggle="modal"
+        data-target="#descriptionModal"
+        data-todoid="${todo.todoID}">
+      Open
+    </button>
+  </div>
+</div>`;
+      }).join('');
+
+      updateStatsBar(todos);
+  }
+
+  export function updateStatsBar(todos: Todo[]): void {
+      const done = todos.filter(t => t.completed).length;
+      const inProgress = todos.length - done;
+      const setCount = (id: string, n: number) => {
+          const el = document.getElementById(id);
+          if (el) el.textContent = String(n);
+      };
+      setCount('statTotal', todos.length);
+      setCount('statInProgress', inProgress);
+      setCount('statDone', done);
   }
 
   export function renderFiles(files: TodoFile[]): void {

--- a/docs/superpowers/specs/2026-04-11-ui-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-11-ui-refresh-design.md
@@ -1,0 +1,162 @@
+# UI Refresh — Chatbot Drawer & Todo Cards
+
+Date: 2026-04-11
+Status: Approved
+
+## Scope
+
+Two areas: chatbot UI (drawer + FAB) and todo list UI (navbar, cards, stats bar).
+CSS and markup changes only — no backend, no API, no routing changes.
+
+Files touched:
+
+- `css/style.css` — chatbot and todo sections rewritten
+- `src/chatbot.ts` — bot avatar markup + path fix
+- `src/ui.ts` — `renderTodos()` card markup
+- `home.html` — navbar, toolbar, stats bar, chat drawer HTML
+
+---
+
+## Color System
+
+Shared across chatbot and todo UI. Single consistent palette.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--teal` | `#0d9488` | Primary accent, active borders, send button, links |
+| `--teal-light` | `#f0fdfa` | Button hover bg, card tint |
+| `--teal-border` | `#99f6e4` | Teal button borders |
+| `--green` | `#22c55e` | Completed status |
+| `--amber` | `#f59e0b` | Overdue status |
+| `--surface` | `#f0f2f5` | Page background |
+| `--card` | `#ffffff` | Card / drawer background |
+| `--text-primary` | `#111827` | Main text |
+| `--text-secondary` | `#64748b` | Secondary / meta text |
+| `--border` | `#e2e8f0` | Borders, dividers |
+
+---
+
+## 1. Navbar
+
+Replace the centered logo block + separate toolbar with a single compact navbar.
+
+**Structure:**
+
+```
+[ logo.png (height 36px) ]   [ search pill ]  [ + New todo ]  [ Sign out ]
+```
+
+- White background, `border-bottom: 1px solid #e5e7eb`, `padding: 12px 20px`
+- Logo: existing `img/logo.png`, `height: 36px`, `width: auto` — no text brand mark
+- Search: pill input (`background: #f1f5f9`, `border-radius: 20px`) + search icon
+- **New todo**: `background: #0d9488`, white text, `border-radius: 8px`
+- **Sign out**: transparent, `border: 1px solid #e2e8f0`, `border-radius: 8px`
+
+---
+
+## 2. Stats Bar
+
+Thin bar below navbar showing live counts.
+
+```
+[ 10 Total ]  [ 6 In Progress ]  [ 4 Done ]
+```
+
+- White pill cards, `border-radius: 8px`, `border: 1px solid #e2e8f0`
+- Count: `font-size: 16px`, `font-weight: 700`
+  - Total: `color: #0d9488`
+  - In Progress: `color: #f59e0b`
+  - Done: `color: #22c55e`
+- Label: `9px`, uppercase, `color: #94a3b8`
+- Counts derived from the `todos` array in `renderTodos()` — no extra API call
+
+---
+
+## 3. Todo Cards
+
+Replaces `renderTodos()` in `ui.ts`. Grid layout unchanged (`col-md-4`).
+
+**Card anatomy:**
+
+```
+┌─ 3px left border (status color) ──────────────────┐
+│  Title (bold)                   [status badge]    │
+│  Description (2 lines max, truncated)             │
+│  📅 Due date                                      │
+│  [ Open ]  (full-width teal button)               │
+└────────────────────────────────────────────────────┘
+```
+
+**Status rules:**
+
+| State | Left border | Badge text | Badge bg | Title style |
+|---|---|---|---|---|
+| In progress | `#0d9488` | `● In progress` | `#f0fdf4 / #16a34a` | Normal |
+| Completed | `#22c55e` | `✓ Done` | `#f0fdf4 / #22c55e` | Strikethrough, muted |
+| Overdue | `#f59e0b` | `⚠ Overdue` | `#fffbeb / #d97706` | Normal |
+
+Overdue = `dateDue < today && !completed`. Computed client-side in `renderTodos()`.
+
+**Open button:** `background: #f0fdfa`, `color: #0d9488`, `border: 1px solid #99f6e4`. Muted on completed cards.
+
+---
+
+## 4. Chatbot — Bottom Drawer
+
+Replaces fixed floating panel. Slides up from bottom, full viewport width.
+
+**Trigger:** FAB click → drawer opens. ✕ button or second FAB click → drawer closes.
+
+**Drawer structure:**
+
+```
+┌── drag handle (centered bar) ─────────────────────┐
+│  [✦ teal avatar]  Assistant        ● Online   [✕] │
+│  ────────────────────────────────────────────────  │
+│  message area (#fafafa bg, scrollable)            │
+│  ────────────────────────────────────────────────  │
+│  [ pill input ........................... ]  [➤]  │
+└────────────────────────────────────────────────────┘
+```
+
+- Height: `45vh`
+- `border-radius: 16px 16px 0 0`
+- `box-shadow: 0 -4px 20px rgba(0,0,0,0.12)`
+- Animation: `transform: translateY(100%)` → `translateY(0)`, `transition: 300ms ease-out`
+- `position: fixed; bottom: 0; left: 0; right: 0; z-index: 1000`
+
+**Header:**
+- Teal circle avatar (32px) with `✦` symbol — replaces SVG bot icon
+- "Assistant" bold label, "● Online" in `#22c55e` below
+- ✕ close button right-aligned
+
+**Messages:**
+- Bot: left-aligned, white bubble `border: 1px solid #e2e8f0`, `border-radius: 4px 14px 14px 14px`, teal ✦ avatar left
+- User: right-aligned, `background: #0d9488`, white text, `border-radius: 14px 4px 14px 14px`
+- Background: `#fafafa`
+
+**Input:**
+- Pill input: `border-radius: 24px`, `background: #f8fafc`
+- Send button: teal circle (36px), `➤` icon
+
+**Bot icon path fix:**
+`src="public/img/bot-icon.svg"` → `src="/img/bot-icon.svg"` in `chatbot.ts`
+
+---
+
+## 5. FAB
+
+- Size: 48px circle
+- `background: linear-gradient(135deg, #0d9488, #0891b2)`
+- `✦` symbol, white, `font-size: 18px`
+- `box-shadow: 0 4px 14px rgba(13,148,136,0.4)`
+- Hidden (`display: none`) when drawer is open; shown when closed
+
+---
+
+## Out of Scope
+
+- Login, register, confirm pages — not touched
+- Modal design (description modal, new todo modal) — not touched in this pass
+- Backend, API, auth — no changes
+- Mobile breakpoints beyond what Bootstrap provides — deferred


### PR DESCRIPTION
## Summary

- Replace centered logo + toolbar with a sticky compact navbar (logo, search pill, New todo, Sign out)
- Add stats bar showing live Total / In Progress / Done counts derived from the todos array
- Replace floating chat panel with a full-width bottom drawer (45vh, slide-up animation) and a teal gradient FAB; ✦ span avatar replaces broken SVG bot icon
- Redesign todo cards with 3px status-colored left borders, status badges (● In progress / ✓ Done / ⚠ Overdue), 2-line truncated description, and teal Open button
- Add shared CSS custom property color system (`--teal`, `--green`, `--amber`, etc.) consumed across all components

## Changes

| File | What changed |
|---|---|
| `apps/web/css/style.css` | `:root` color tokens; navbar, stats bar, card, drawer, FAB styles; removed old floating chat styles |
| `apps/web/home.html` | New navbar + stats bar; chatbot drawer + FAB replacing old `.chat-tab` / `.chat-container` |
| `apps/web/src/ui.ts` | Rewrote `renderTodos()` with status logic; added `updateStatsBar()` |
| `apps/web/src/chatbot.ts` | `displayMessage()` uses `✦` span avatar instead of broken SVG path |
| `apps/web/src/pages/home.ts` | Chatbot toggle uses `#chatFab` / `#chatDrawer` / `#chatCloseBtn` |

## Test Plan

- [x] `cd apps/web && npm run build` passes with no TypeScript errors
- [ ] Dev server: navbar shows logo, search pill, New todo (teal), Sign out (outline) in one row
- [ ] Stats bar shows 3 pills with correct colors (teal / amber / green)
- [ ] FAB visible bottom-right; click opens drawer with slide-up animation; FAB hides
- [ ] ✕ button closes drawer; FAB reappears
- [ ] Todo cards show 3px left border (teal=in-progress, green=done, amber=overdue)
- [ ] Stats counts update after todos load
- [ ] Existing modals (description, new todo) still function unchanged
- [ ] Login / register / confirm pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)