### PR TITLE
feat(chat): add paperclip button and keyword-triggered inline upload

### DIFF
--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -374,6 +374,39 @@ p {
     flex-shrink: 0;
 }
 
+.chat-attach-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #f0f0f0;
+    color: var(--text-secondary);
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 150ms;
+}
+
+.chat-attach-btn:hover {
+    background: var(--teal);
+    color: #fff;
+}
+
+.chat-upload-btn {
+    display: block;
+    margin-top: 8px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    background: var(--teal);
+    color: #fff;
+    font-size: 12px;
+    border: none;
+    cursor: pointer;
+}
+
 /* ── Navbar ─────────────────────────────────────── */
 .site-navbar {
     display: flex;

--- a/apps/web/home.html
+++ b/apps/web/home.html
@@ -59,9 +59,11 @@
         </div>
         <div class="chat-messages" id="chatMessages"></div>
         <div class="chat-input-row">
+            <button id="chatAttachBtn" class="chat-attach-btn" aria-label="Attach file" type="button">📎</button>
             <input type="text" id="userInput" placeholder="Type a message…" class="chat-pill-input">
             <button id="sendMessageButton" class="chat-send-btn">➤</button>
         </div>
+        <input type="file" id="chatFileInput" style="display:none" accept="*/*">
     </div>
 
     <!-- Todos list -->

--- a/apps/web/src/chatbot.ts
+++ b/apps/web/src/chatbot.ts
@@ -177,11 +177,42 @@ export function sendMessage(): void {
     ws.send(JSON.stringify({ human: message }));
 }
 
+async function _handleFileUpload(file: File): Promise<void> {
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+        displayMessage('Not connected. Please open the chat panel again.', 'bot', false);
+        return;
+    }
+
+    displayMessage(`Uploading ${file.name}…`, 'bot', false);
+    displayTypingIndicator();
+
+    try {
+        const { uploadToS3 } = await import('./s3upload');
+        const { config: appConfig } = await import('./config');
+        const todoID = localStorage.getItem('todoID') ?? '';
+        const key = await uploadToS3(file, todoID || 'unassigned');
+        const fileUrl = `https://${appConfig.cdnDomain}/${key}`;
+
+        removeTypingIndicator();
+
+        const msg = todoID
+            ? `I just uploaded "${file.name}". Its URL is: ${fileUrl}. Please attach it to the currently open todo.`
+            : `I just uploaded "${file.name}". Its URL is: ${fileUrl}. Please ask me which todo to attach it to.`;
+
+        displayMessage(msg, 'user');
+        displayTypingIndicator();
+        ws.send(JSON.stringify({ human: msg }));
+    } catch (err) {
+        removeTypingIndicator();
+        displayMessage('File upload failed. Please try again.', 'bot', false);
+        console.error('[chatbot] file upload error:', err);
+    }
+}
+
 export function initChatDropZone(): void {
     const drawer = document.getElementById('chatDrawer');
     if (!drawer) return;
 
-    // Prevent re-registering listeners
     if (drawer.dataset.dropzoneInit) return;
     drawer.dataset.dropzoneInit = '1';
 
@@ -198,33 +229,7 @@ export function initChatDropZone(): void {
         e.preventDefault();
         drawer.classList.remove('drag-over');
         const file = e.dataTransfer?.files?.[0];
-        if (!file || !ws || ws.readyState !== WebSocket.OPEN) return;
-
-        displayMessage(`Uploading ${file.name}…`, 'bot', false);
-        displayTypingIndicator();
-
-        try {
-            const { uploadToS3 } = await import('./s3upload');
-            const { config: appConfig } = await import('./config');
-            const todoID = localStorage.getItem('todoID') ?? '';
-            const key = await uploadToS3(file, todoID || 'unassigned');
-            const fileUrl = `https://${appConfig.cdnDomain}/${key}`;
-
-            removeTypingIndicator();
-            displayMessage(
-                `File "${file.name}" uploaded. I'll ask the AI to attach it to a todo.`,
-                'bot',
-                false,
-            );
-
-            const msg = `I just uploaded a file named "${file.name}". Its URL is: ${fileUrl}. Please attach it to the appropriate todo, or ask me which todo to attach it to.`;
-            displayMessage(msg, 'user');
-            displayTypingIndicator();
-            ws.send(JSON.stringify({ human: msg }));
-        } catch (err) {
-            removeTypingIndicator();
-            displayMessage('File upload failed. Please try again.', 'bot', false);
-            console.error('[chatbot] drop upload error:', err);
-        }
+        if (!file) return;
+        await _handleFileUpload(file);
     });
 }

--- a/apps/web/src/chatbot.ts
+++ b/apps/web/src/chatbot.ts
@@ -9,6 +9,7 @@ interface PersistedMessage {
 
 const CHAT_HISTORY_KEY = 'chatHistory';
 const CHAT_FRESH_KEY = 'chatFreshSession';
+const UPLOAD_INTENT_RE = /upload|attach|add a file|share a file|provide the file|drag.*file|file.*url/i;
 
 let ws: WebSocket | null = null;
 let _intentionalClose = false;
@@ -130,6 +131,7 @@ export function displayMessage(text: string, sender: Sender = 'user', persist = 
 
     if (sender === 'bot') {
         messageElement.innerHTML = '<span class="bot-avatar-sm">✦</span>' + formatBotText(text);
+        if (persist) _maybeAppendUploadButton(messageElement);
     } else {
         messageElement.textContent = text;
     }
@@ -175,6 +177,20 @@ export function sendMessage(): void {
     displayTypingIndicator();
 
     ws.send(JSON.stringify({ human: message }));
+}
+
+function _maybeAppendUploadButton(el: HTMLElement): void {
+    const text = el.textContent ?? '';
+    if (!UPLOAD_INTENT_RE.test(text)) return;
+    const btn = document.createElement('button');
+    btn.className = 'chat-upload-btn';
+    btn.type = 'button';
+    btn.textContent = '📎 Upload file';
+    btn.addEventListener('click', () => {
+        const fileInput = document.getElementById('chatFileInput') as HTMLInputElement | null;
+        fileInput?.click();
+    });
+    el.appendChild(btn);
 }
 
 async function _handleFileUpload(file: File): Promise<void> {
@@ -229,6 +245,24 @@ export function initChatDropZone(): void {
         e.preventDefault();
         drawer.classList.remove('drag-over');
         const file = e.dataTransfer?.files?.[0];
+        if (!file) return;
+        await _handleFileUpload(file);
+    });
+}
+
+export function initChatFileInput(): void {
+    const fileInput = document.getElementById('chatFileInput') as HTMLInputElement | null;
+    const attachBtn = document.getElementById('chatAttachBtn') as HTMLButtonElement | null;
+    if (!fileInput || !attachBtn) return;
+
+    if (fileInput.dataset.chatInit) return;
+    fileInput.dataset.chatInit = '1';
+
+    attachBtn.addEventListener('click', () => fileInput.click());
+
+    fileInput.addEventListener('change', async () => {
+        const file = fileInput.files?.[0];
+        fileInput.value = '';
         if (!file) return;
         await _handleFileUpload(file);
     });

--- a/apps/web/src/pages/home.ts
+++ b/apps/web/src/pages/home.ts
@@ -1,6 +1,6 @@
 import { getTodos, getTodo, addTodo, completeTodo, deleteTodo, addTodoNotes } from '../api';
 import { logOut } from '../auth';
-import { sendMessage, openChatSession, closeChatSession, restoreChatHistory, clearChatHistory, initChatDropZone } from '../chatbot';
+import { sendMessage, openChatSession, closeChatSession, restoreChatHistory, clearChatHistory, initChatDropZone, initChatFileInput } from '../chatbot';
 import { renderTodos, markCompleted, showAddFilesForm, hideAddFilesForm, addFileName } from '../ui';
 import { Todo } from '../types';
 
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         chatFab.style.display = 'none';
         openChatSession();
         initChatDropZone();
+        initChatFileInput();
         (document.getElementById('userInput') as HTMLInputElement)?.focus();
     }
 

--- a/docs/superpowers/plans/2026-04-18-chatbot-file-upload.md
+++ b/docs/superpowers/plans/2026-04-18-chatbot-file-upload.md
@@ -1,0 +1,384 @@
+# Chatbot File Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a paperclip button to the chat input row and keyword-triggered inline upload buttons so users can pick files from within the chatbot drawer.
+
+**Architecture:** A single hidden `<input type="file" id="chatFileInput">` is shared by all triggers. A new `initChatFileInput()` function wires up the paperclip button and the file input's `change` handler. A shared `_handleFileUpload()` helper (private to `chatbot.ts`) deduplicates the upload-and-send logic currently inlined in the drop zone. After every bot message is rendered, a keyword regex check optionally appends an inline "📎 Upload file" button to the bubble.
+
+**Tech Stack:** TypeScript, Vite, AWS SDK v3 S3 (`@aws-sdk/client-s3`), WebSocket, vanilla DOM
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `apps/web/home.html` | Modify | Add `#chatAttachBtn` + `#chatFileInput` to chat drawer |
+| `apps/web/css/style.css` | Modify | Add `.chat-attach-btn` and `.chat-upload-btn` styles |
+| `apps/web/src/chatbot.ts` | Modify | Extract `_handleFileUpload()`, add `initChatFileInput()`, add keyword scanner in `displayMessage()` |
+| `apps/web/src/pages/home.ts` | Modify | Import + call `initChatFileInput()` in `openDrawer()` |
+
+---
+
+## Task 1: Add HTML structure
+
+**Files:**
+- Modify: `apps/web/home.html:61-64`
+
+- [ ] **Step 1: Add the paperclip button and hidden file input**
+
+  Open `apps/web/home.html`. Replace lines 61-64 (the `chat-input-row` div and its closing tag):
+
+  ```html
+          <div class="chat-input-row">
+              <button id="chatAttachBtn" class="chat-attach-btn" aria-label="Attach file" type="button">📎</button>
+              <input type="text" id="userInput" placeholder="Type a message…" class="chat-pill-input">
+              <button id="sendMessageButton" class="chat-send-btn">➤</button>
+          </div>
+          <input type="file" id="chatFileInput" style="display:none" accept="*/*">
+  ```
+
+  The hidden file input goes **after** the `chat-input-row` div, still inside `#chatDrawer`.
+
+- [ ] **Step 2: Verify the markup compiles**
+
+  Run:
+  ```bash
+  cd apps/web && npm run build 2>&1 | tail -5
+  ```
+  Expected: build succeeds with no errors (TypeScript does not parse HTML, so this just confirms the build pipeline still works).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add apps/web/home.html
+  git commit -m "feat(chat): add paperclip button and hidden file input to drawer"
+  ```
+
+---
+
+## Task 2: Add CSS styles
+
+**Files:**
+- Modify: `apps/web/css/style.css` (after `.chat-send-btn` block, around line 375)
+
+- [ ] **Step 1: Add button styles after the `.chat-send-btn` block**
+
+  In `apps/web/css/style.css`, after the closing `}` of `.chat-send-btn` (line 375), insert:
+
+  ```css
+  .chat-attach-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: #f0f0f0;
+      color: var(--text-secondary);
+      border: none;
+      font-size: 16px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 150ms;
+  }
+
+  .chat-attach-btn:hover {
+      background: var(--teal);
+      color: #fff;
+  }
+
+  .chat-upload-btn {
+      display: block;
+      margin-top: 8px;
+      padding: 4px 12px;
+      border-radius: 12px;
+      background: var(--teal);
+      color: #fff;
+      font-size: 12px;
+      border: none;
+      cursor: pointer;
+  }
+  ```
+
+- [ ] **Step 2: Verify build**
+
+  ```bash
+  cd apps/web && npm run build 2>&1 | tail -5
+  ```
+  Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add apps/web/css/style.css
+  git commit -m "feat(chat): add styles for attach button and inline upload button"
+  ```
+
+---
+
+## Task 3: Refactor drop zone + add upload logic in chatbot.ts
+
+**Files:**
+- Modify: `apps/web/src/chatbot.ts`
+
+The drop zone currently has the upload-and-send logic inlined. Extract it into a shared private helper so the new file input can reuse it without duplication.
+
+- [ ] **Step 1: Add `_handleFileUpload` private helper**
+
+  In `apps/web/src/chatbot.ts`, add this function directly above `export function initChatDropZone()` (before line 180):
+
+  ```typescript
+  async function _handleFileUpload(file: File): Promise<void> {
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+          displayMessage('Not connected. Please open the chat panel again.', 'bot', false);
+          return;
+      }
+
+      displayMessage(`Uploading ${file.name}…`, 'bot', false);
+      displayTypingIndicator();
+
+      try {
+          const { uploadToS3 } = await import('./s3upload');
+          const { config: appConfig } = await import('./config');
+          const todoID = localStorage.getItem('todoID') ?? '';
+          const key = await uploadToS3(file, todoID || 'unassigned');
+          const fileUrl = `https://${appConfig.cdnDomain}/${key}`;
+
+          removeTypingIndicator();
+
+          const msg = todoID
+              ? `I just uploaded "${file.name}". Its URL is: ${fileUrl}. Please attach it to the currently open todo.`
+              : `I just uploaded "${file.name}". Its URL is: ${fileUrl}. Please ask me which todo to attach it to.`;
+
+          displayMessage(msg, 'user');
+          displayTypingIndicator();
+          ws.send(JSON.stringify({ human: msg }));
+      } catch (err) {
+          removeTypingIndicator();
+          displayMessage('File upload failed. Please try again.', 'bot', false);
+          console.error('[chatbot] file upload error:', err);
+      }
+  }
+  ```
+
+- [ ] **Step 2: Refactor `initChatDropZone` to use `_handleFileUpload`**
+
+  Replace the `drop` handler inside `initChatDropZone` (lines 197-229). The full updated `initChatDropZone` should read:
+
+  ```typescript
+  export function initChatDropZone(): void {
+      const drawer = document.getElementById('chatDrawer');
+      if (!drawer) return;
+
+      if (drawer.dataset.dropzoneInit) return;
+      drawer.dataset.dropzoneInit = '1';
+
+      drawer.addEventListener('dragover', (e: DragEvent) => {
+          e.preventDefault();
+          drawer.classList.add('drag-over');
+      });
+
+      drawer.addEventListener('dragleave', () => {
+          drawer.classList.remove('drag-over');
+      });
+
+      drawer.addEventListener('drop', async (e: DragEvent) => {
+          e.preventDefault();
+          drawer.classList.remove('drag-over');
+          const file = e.dataTransfer?.files?.[0];
+          if (!file) return;
+          await _handleFileUpload(file);
+      });
+  }
+  ```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+  ```bash
+  cd apps/web && npm run build 2>&1 | tail -5
+  ```
+  Expected: build succeeds, no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add apps/web/src/chatbot.ts
+  git commit -m "refactor(chat): extract _handleFileUpload helper from drop zone"
+  ```
+
+---
+
+## Task 4: Add keyword scanner and `initChatFileInput` to chatbot.ts
+
+**Files:**
+- Modify: `apps/web/src/chatbot.ts`
+
+- [ ] **Step 1: Add the upload-intent regex constant**
+
+  At the top of `apps/web/src/chatbot.ts`, after the existing constants (after line 18, `SESSION_TTL_SECONDS`), add:
+
+  ```typescript
+  const UPLOAD_INTENT_RE = /upload|attach|add a file|share a file|provide the file|drag.*file|file.*url/i;
+  ```
+
+- [ ] **Step 2: Add `_maybeAppendUploadButton` private helper**
+
+  Add this function directly above `_handleFileUpload` (which you added in Task 3):
+
+  ```typescript
+  function _maybeAppendUploadButton(el: HTMLElement): void {
+      const text = el.textContent ?? '';
+      if (!UPLOAD_INTENT_RE.test(text)) return;
+      const btn = document.createElement('button');
+      btn.className = 'chat-upload-btn';
+      btn.type = 'button';
+      btn.textContent = '📎 Upload file';
+      btn.addEventListener('click', () => {
+          const fileInput = document.getElementById('chatFileInput') as HTMLInputElement | null;
+          fileInput?.click();
+      });
+      el.appendChild(btn);
+  }
+  ```
+
+- [ ] **Step 3: Call `_maybeAppendUploadButton` inside `displayMessage` for bot messages**
+
+  In `displayMessage`, find the block that handles `sender === 'bot'` (around line 131-133):
+
+  ```typescript
+  if (sender === 'bot') {
+      messageElement.innerHTML = '<span class="bot-avatar-sm">✦</span>' + formatBotText(text);
+  }
+  ```
+
+  Replace it with:
+
+  ```typescript
+  if (sender === 'bot') {
+      messageElement.innerHTML = '<span class="bot-avatar-sm">✦</span>' + formatBotText(text);
+      if (persist) _maybeAppendUploadButton(messageElement);
+  }
+  ```
+
+  The `persist` guard ensures the upload button only appears on live messages — not when history is restored from `localStorage` (where `displayMessage` is called with `persist = false`).
+
+- [ ] **Step 4: Add `initChatFileInput` export**
+
+  Add this exported function at the end of `apps/web/src/chatbot.ts` (after `initChatDropZone`):
+
+  ```typescript
+  export function initChatFileInput(): void {
+      const fileInput = document.getElementById('chatFileInput') as HTMLInputElement | null;
+      const attachBtn = document.getElementById('chatAttachBtn') as HTMLButtonElement | null;
+      if (!fileInput || !attachBtn) return;
+
+      if (fileInput.dataset.chatInit) return;
+      fileInput.dataset.chatInit = '1';
+
+      attachBtn.addEventListener('click', () => fileInput.click());
+
+      fileInput.addEventListener('change', async () => {
+          const file = fileInput.files?.[0];
+          fileInput.value = '';
+          if (!file) return;
+          await _handleFileUpload(file);
+      });
+  }
+  ```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+  ```bash
+  cd apps/web && npm run build 2>&1 | tail -5
+  ```
+  Expected: build succeeds, no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add apps/web/src/chatbot.ts
+  git commit -m "feat(chat): add keyword scanner and initChatFileInput for click-to-upload"
+  ```
+
+---
+
+## Task 5: Wire up in home.ts
+
+**Files:**
+- Modify: `apps/web/src/pages/home.ts:1-3`
+
+- [ ] **Step 1: Import `initChatFileInput`**
+
+  In `apps/web/src/pages/home.ts`, update the import from `../chatbot` (line 2):
+
+  ```typescript
+  import { sendMessage, openChatSession, closeChatSession, restoreChatHistory, clearChatHistory, initChatDropZone, initChatFileInput } from '../chatbot';
+  ```
+
+- [ ] **Step 2: Call `initChatFileInput()` in `openDrawer`**
+
+  In `home.ts`, find the `openDrawer` function (around line 26). Add the call after `initChatDropZone()`:
+
+  ```typescript
+  function openDrawer(): void {
+      if (!chatDrawer || !chatFab) return;
+      chatDrawer.classList.add('open');
+      chatFab.style.display = 'none';
+      openChatSession();
+      initChatDropZone();
+      initChatFileInput();
+      (document.getElementById('userInput') as HTMLInputElement)?.focus();
+  }
+  ```
+
+- [ ] **Step 3: Verify TypeScript compiles cleanly**
+
+  ```bash
+  cd apps/web && npm run build 2>&1 | tail -5
+  ```
+  Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add apps/web/src/pages/home.ts
+  git commit -m "feat(chat): wire up initChatFileInput in openDrawer"
+  ```
+
+---
+
+## Task 6: Manual verification
+
+- [ ] **Step 1: Run local dev server**
+
+  ```bash
+  cd apps/web && npm run dev
+  ```
+  Open `http://localhost:5173/home.html` (requires being logged in — use `.env.local` credentials).
+
+- [ ] **Step 2: Verify paperclip button appears**
+
+  Open the chat drawer. Confirm a 📎 button appears to the left of the text input. Hovering it should turn it teal.
+
+- [ ] **Step 3: Verify click-to-upload via paperclip**
+
+  Click 📎. A native file picker should open. Select any file. Confirm:
+  - An "Uploading filename…" bot bubble appears
+  - A user bubble with the file URL appears
+  - The agent responds (may ask which todo if none is open, or attach directly if a todo modal was open)
+
+- [ ] **Step 4: Verify inline upload button appears on agent prompts**
+
+  Type: `I want to add a file to a todo` and send. When the agent responds with language like "please upload" or "attach", confirm a `📎 Upload file` pill button appears at the bottom of that bot bubble.
+
+- [ ] **Step 5: Verify drop zone still works**
+
+  Drag a file onto the chat drawer. Confirm it still uploads and sends as before (regression check).
+
+- [ ] **Step 6: Push branch**
+
+  ```bash
+  git push origin feat/cloudfront-oac-nova-agent-refresh
+  ```

--- a/docs/superpowers/specs/2026-04-18-chatbot-file-upload-design.md
+++ b/docs/superpowers/specs/2026-04-18-chatbot-file-upload-design.md
@@ -1,0 +1,161 @@
+# Design: Chatbot File Upload
+
+- **Date:** 2026-04-18
+- **Status:** Approved
+
+---
+
+## Context
+
+The chatbot drawer supports drag-and-drop file upload onto the drawer surface, but has
+no click-to-upload affordance. When a user types "add a file to this todo", the agent
+responds with text instructions but there is no way to actually pick a file from within
+the chat UI. This design adds two complementary triggers for file upload inside the chat.
+
+---
+
+## Goals
+
+- Always-visible paperclip button in the chat input row
+- Agent responses containing upload-intent language automatically get an inline
+  "Upload file" button appended to the message bubble
+- Selecting a file through either trigger runs the same upload flow as the existing
+  drop zone and sends the result to the agent via WebSocket
+
+## Non-goals
+
+- Backend / WebSocket protocol changes
+- Replacing or removing the existing drag-and-drop drop zone
+- Multi-file upload in a single interaction
+
+---
+
+## Approach
+
+A single hidden `<input type="file">` lives in the DOM. Both the paperclip button and
+any inline upload button call `.click()` on it. The `change` handler executes the upload
+and sends the file URL to the agent. Keyword detection runs in `chatbot.ts` after every
+bot message is rendered.
+
+---
+
+## UI Changes
+
+### `apps/web/home.html`
+
+Add to `.chat-input-row`, before the text input:
+
+```html
+<button id="chatAttachBtn" class="chat-attach-btn" aria-label="Attach file" type="button">📎</button>
+```
+
+Add after `.chat-input-row` (hidden, outside the row):
+
+```html
+<input type="file" id="chatFileInput" style="display:none" accept="*/*">
+```
+
+Result:
+
+```
+[ 📎 attach ] [ text input ] [ ➤ send ]
+```
+
+### `apps/web/css/style.css`
+
+**Paperclip button** — same size as send button, neutral colour, teal on hover:
+
+```css
+.chat-attach-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: #f0f0f0;
+    color: var(--text-secondary);
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: background 150ms;
+}
+.chat-attach-btn:hover {
+    background: var(--teal);
+    color: #fff;
+}
+```
+
+**Inline upload button** — small pill appended to bot message bubbles:
+
+```css
+.chat-upload-btn {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 4px 12px;
+    border-radius: 12px;
+    background: var(--teal);
+    color: #fff;
+    font-size: 12px;
+    border: none;
+    cursor: pointer;
+}
+```
+
+---
+
+## Keyword Detection
+
+After every bot message is rendered, `chatbot.ts` scans the text against a
+case-insensitive regex. If matched, a `<button class="chat-upload-btn">` is appended
+to that message bubble.
+
+Trigger pattern:
+
+```
+/upload|attach|add a file|share a file|provide the file|drag.*file|file.*url/i
+```
+
+The button is injected once per message and is **not** persisted to `localStorage`
+(will not re-appear on history restore — the paperclip is always available as fallback).
+
+---
+
+## Upload Flow
+
+Triggered by either the paperclip button or an inline upload button:
+
+1. Open the hidden `<input type="file">` via `.click()`
+2. On `change`, read the selected `File`
+3. Read `localStorage.getItem('todoID')` (currently open todo, may be empty)
+4. Call `uploadToS3(file, todoID || 'unassigned')` — existing function, unchanged
+5. Build CDN URL: `` `https://${config.cdnDomain}/${key}` ``
+6. Display user bubble:
+   - If `todoID` set: `I just uploaded "filename". Please attach it to the currently open todo.`
+   - If no `todoID`: `I just uploaded "filename". Its URL is: <url>. Please ask me which todo to attach it to.`
+7. Send the bubble text as the WebSocket message
+8. Agent calls `addTodoFile` with the todo and file URL
+
+This is the same pattern as the existing drop zone handler — the file input is a
+click-triggered equivalent of drag-and-drop.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/home.html` | Add `#chatAttachBtn` button and `#chatFileInput` hidden input |
+| `apps/web/css/style.css` | Add `.chat-attach-btn` and `.chat-upload-btn` styles |
+| `apps/web/src/chatbot.ts` | Add `initChatFileInput()`, keyword scanner in `displayMessage()`, wire `#chatAttachBtn` click in `home.ts` |
+
+No backend changes required.
+
+---
+
+## Error Handling
+
+- If upload fails, display bot bubble: `"File upload failed. Please try again."` (same as drop zone)
+- If WebSocket is not open when file is selected, display: `"Not connected. Please open the chat panel again."` and abort
+- Reset the file input value after each selection so the same file can be re-selected if needed


### PR DESCRIPTION
## Summary
- Adds a 📎 paperclip button to the chat input row that opens a native file picker
- Extracts shared `_handleFileUpload()` helper from the drop zone (no logic duplication)
- Adds keyword regex scanner that appends an inline \"📎 Upload file\" button to bot bubbles when the response contains upload-related language

## Test Plan
- [ ] Open chat drawer — paperclip button appears to the left of the text input, turns teal on hover
- [ ] Click 📎 — native file picker opens; selecting a file triggers upload and sends a message with the file URL
- [ ] Type \"I want to add a file to a todo\" — bot response with upload language shows an inline \"📎 Upload file\" pill button
- [ ] Drag a file onto the drawer — still uploads correctly (regression check)
- [ ] Reload chat — restored history messages do not show the upload button