### PR TITLE
feat: harden chatbot against prompt injection (5 layers)

### DIFF
--- a/infra/sam/ai-assistant/template.yaml
+++ b/infra/sam/ai-assistant/template.yaml
@@ -547,7 +547,7 @@ Resources:
   TodoChatbotGuardrail:
     Type: AWS::Bedrock::Guardrail
     Properties:
-      Name: !Sub "${AWS::StackName}-prompt-injection-guard"
+      Name: !Sub "${AWS::StackName}-guardrail"
       BlockedInputMessaging: "I'm here to help with your todos. I can't help with that request."
       BlockedOutputsMessaging: "I'm unable to share that information."
       ContentPolicyConfig:


### PR DESCRIPTION
## Summary

Refactors the Bedrock Agent chatbot to defend against prompt injection and tool-call abuse. Five-layer defense, mapped from a threat model that includes the unique-to-Bedrock-Agents action-call abuse surface.

**Key insight (Phase B — the headline):** `promptSessionAttributes` is a hint to the model, not an enforcement boundary. The substitution lands in the agent *instruction* the model reads, but the model can still be coerced into passing a different `userID` parameter when it calls a tool. The action group Lambda is the only real trust boundary — it now reads `userID` authoritatively from `event['promptSessionAttributes']` and ignores the function parameter, plus enforces ownership on every `todoID`/`fileID` access.

## What changed

**Auth hygiene (Phase A)**
- Authorizer enforces JWT `aud` (audience) against `COGNITO_CLIENT_ID` + requires `token_use == 'id'` (rejects access tokens)
- `COGNITO_CLIENT_ID` sourced from SSM (`/todo-houessou-com/main-service/cognito-client-id`)
- WebSocket handler streams Bedrock chunks per-frame instead of buffering; frontend appends progressively
- Pipeline `Read config` step gets `set -euo pipefail` so missing SSM values fail loud

**Action group as the trust boundary (Phase B)**
- `userID` read from `event['promptSessionAttributes']` / `event['sessionAttributes']` only — function parameter ignored
- `_assert_owns_todo` ownership check on every `todoID`-bearing function (`getTodo`, `addTodoNotes`, `completeTodo`, `deleteTodo`, `listTodoFiles`, `addTodoFile`, `deleteTodoFile`)
- CDN URL allowlist on `addTodoFile` (`fileUrl` must start with `https://{FILES_BUCKET_CDN}/`)
- Legacy `_clean_user_id` (XML-tag stripping) removed
- DynamoDB exceptions in `_assert_owns_todo` fail closed + emit metric
- Inner functions return dicts; dispatcher serializes once (fixes prior double-encoding)

**Lambda input gates + output validation (Phase C)**
- 1000-char input cap → `LengthExceeded`
- Regex pattern scan against injection blocklist → `InjectionBlocked`
- HTML-comment stripping (defense against indirect injection in pasted content)
- `<query>...</query>` delimiter wrap before sending to agent
- Output regex scan against instruction-leak patterns → `OutputBlocked`

**Rate limiting (Phase D)**
- Per-user DynamoDB fixed-window counter (30 messages / 5 min) — closes the WAF gap that WebSocket APIs leave open
- API Gateway WebSocket stage throttle (burst 10, rate 5)

**Bedrock Guardrail + observability (Phase E)**
- `AWS::Bedrock::Guardrail` attached to the Agent via `GuardrailConfiguration`
- PROMPT_ATTACK content filter (HIGH input strength)
- Topic deny policies: `prompt-extraction`, `role-override`, `off-topic-non-todo`
- Word blocklist + PROFANITY managed list
- PII anonymization (EMAIL, PHONE)
- CloudWatch namespace `LLMSecurity/TodoChatbot` with 5 counters: `InjectionBlocked`, `OutputBlocked`, `RateLimited`, `LengthExceeded`, `UnauthorizedActionAttempt`
- 3 alarms wired to SNS topic; email subscription via `AlertEmail` parameter (sourced from SSM, gracefully missing)

## Notable gotcha (worth its own log entry)

CloudFormation's `AWS::EarlyValidation::PropertyValidation` hook silently rejects changesets when properties violate schema constraints — but `DescribeEvents` returns nothing useful, so the failure is opaque. Hit this on the Guardrail's `Name` field: `${AWS::StackName}-prompt-injection-guard` resolved to 53 chars, exceeding the 50-char schema max. Shortened to `${AWS::StackName}-guardrail`. Bisected by deploying isolation stacks + reverting in chunks because the error message has no actionable detail.

## Test plan

- [x] All unit tests pass (22/22 — was 11 baseline + 11 new)
- [x] `sam validate` passes
- [x] Local deploy succeeds against `todo-houessou-com-ai-assistant`
- [x] Live verification: Guardrail attached to agent (`vh27nsevrkdm` DRAFT), SNS topic + 3 alarms exist, CloudWatch metrics namespace ready
- [ ] Pipeline run reaches converged state (no diff)
- [ ] Demo attacks captured pre/post for blog series:
  - System prompt extraction → caught by Lambda regex scan
  - Role override → caught by Bedrock Guardrail (PROMPT_ATTACK + word blocklist)
  - Cross-user via tool injection (`userID=victim@…`) → caught by action group ownership check (the headline demo)

## Follow-ups (not in this PR)

- Implementation log + blog input summary update (Phase G)
- Two-part blog series: build narrative + harden narrative (Phase H)

🤖 Generated with [Claude Code](https://claude.com/claude-code)