### PR TITLE
fix(chatbot): enable real Bedrock Agent token streaming

### DIFF
--- a/infra/sam/ai-assistant/template.yaml
+++ b/infra/sam/ai-assistant/template.yaml
@@ -375,7 +375,9 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: bedrock:InvokeModel
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
                 Resource: !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/amazon.nova-lite-v1:0"
               - Effect: Allow
                 Action: lambda:InvokeFunction

--- a/services/ai-assistant/src/websocket_handler/handler.py
+++ b/services/ai-assistant/src/websocket_handler/handler.py
@@ -241,6 +241,9 @@ def _default(connection_id, user_id, body_str):
         sessionState={
             'promptSessionAttributes': {'userID': user_id},
         },
+        streamingConfigurations={
+            'streamFinalResponse': True,
+        },
     )
 
     agent_answer = ''

--- a/services/ai-assistant/src/websocket_handler/handler.py
+++ b/services/ai-assistant/src/websocket_handler/handler.py
@@ -323,12 +323,5 @@ def lambda_handler(event, context):
                 'level': 'ERROR', 'route': '$default',
                 'connectionId': connection_id, 'error': str(exc),
             }))
-            if _api_gw_mgmt:
-                try:
-                    _api_gw_mgmt.post_to_connection(
-                        ConnectionId=connection_id,
-                        Data=json.dumps({'response': 'Sorry, something went wrong. Please try again.'}),
-                    )
-                except Exception:
-                    pass
+            _post_error(connection_id, 'InternalError', 'Sorry, something went wrong. Please try again.')
             raise


### PR DESCRIPTION
## Summary

The Phase 3 streaming refactor (per-chunk \`post_to_connection\`) was correct, but Bedrock Agent's \`invoke_agent\` doesn't stream tokens by default — it returns the full final response as a single chunk event. The frontend's progressive-render path was never exercised in practice.

This PR opts in to real token streaming via \`streamingConfigurations.streamFinalResponse=True\` and grants the agent role the IAM action it needs to actually stream from the model.

## Changes

- **Add \`streamingConfigurations\` to \`invoke_agent\`** — \`streamFinalResponse: True\`. One-line change in \`websocket_handler/handler.py\`.
- **Grant \`bedrock:InvokeModelWithResponseStream\`** to the \`TodoAgentRole\` foundation-model resource. Without it, \`InvokeAgent\` fails mid-stream with \`accessDeniedException\` once streaming is enabled.
- **Use the new error-frame protocol on the lambda_handler catch-all.** Previously it posted the legacy \`{response: ...}\` payload, which the streaming-aware frontend silently ignores → user sees the typing indicator hang forever. Now uses \`_post_error(connection_id, 'InternalError', ...)\` so any unexpected exception surfaces as a visible error frame.

## Test plan

- [x] All 22 unit tests pass
- [x] \`sam validate\` passes
- [x] Local deploy succeeded
- [x] Manual: verbose prompt (\`describe all my todos with full notes\`) renders progressively in the chat bubble — confirmed mid-stream screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)