### PR TITLE
feat(chat): render bold and inline code in bot messages

### DIFF
--- a/apps/web/css/style.css
+++ b/apps/web/css/style.css
@@ -307,6 +307,14 @@ p {
     gap: 8px;
 }
 
+.message.bot code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 0.92em;
+    background: rgba(0, 0, 0, 0.05);
+    padding: 1px 4px;
+    border-radius: 3px;
+}
+
 .bot-avatar-sm {
     width: 20px;
     height: 20px;

--- a/apps/web/src/chatbot.ts
+++ b/apps/web/src/chatbot.ts
@@ -45,11 +45,19 @@ export function clearChatHistory(): void {
 }
 
 function formatBotText(text: string): string {
-    return text
+    let s = text
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/\n/g, '<br>');
+        .replace(/>/g, '&gt;');
+
+    // Inline markdown — bold and code. Applied AFTER escaping so the source
+    // text can't introduce HTML; the tags we emit here are the only HTML
+    // in the output.
+    s = s.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+    s = s.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+
+    s = s.replace(/\n/g, '<br>');
+    return s;
 }
 
 export function openChatSession(): void {


### PR DESCRIPTION
Bedrock Agent emits markdown (\`**bold**\`, \`\` \`code\` \`\`); the chat bubble was rendering it as literal asterisks/backticks. Adds inline markdown handling to \`formatBotText\` for those two cases.

HTML-escape runs FIRST, then markdown transforms run on the escaped text and emit only the safe tags we control — XSS-safe by construction.

Skipped italic (\`*x*\`) on purpose — too high a false-positive rate against single asterisks in regular prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)